### PR TITLE
Apama Core Community Edition version 10.2.0.1 on Ubuntu 18.04 (amd64)

### DIFF
--- a/apamacore-ubuntu_amd64/Dockerfile
+++ b/apamacore-ubuntu_amd64/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:18.04 as acce_build
+# Get/download the compressed archive of Apama Core Community Edition, and unzip it
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+RUN \
+    ACCE_BASE_URL="https://downloads.apamacommunity.com/apama-core/10.2.0.1" && \
+    ACCE_TGZ_FILE="apama_core_10.2.0.1_amd64_linux.tar.gz" && \
+    ACCE_INSTALL_FOLDER="/opt/apamacce" && \
+    mkdir $ACCE_INSTALL_FOLDER && \
+    curl -s $ACCE_BASE_URL/$ACCE_TGZ_FILE | tar -xvz -C $ACCE_INSTALL_FOLDER 
+
+
+# Now make the real image that does not include 14MB of curl and dependencies
+FROM ubuntu:18.04
+
+LABEL \
+    name="Apama Core Community Edition" \
+    arch="x86-64" \
+    base="ubuntu:18.04" \
+    maintainer="Kev Palfreyman (@kpalf)" \
+    build-date="20180512"
+
+# Get/download the compressed archive of Apama Core Community Edition, and unzip it
+COPY --from=acce_build /opt/apamacce /opt/apamacce
+
+# Set environment variables inside the image
+ENV \
+    APAMA_HOME=/opt/apamacce/Apama \
+    PATH=/opt/apamacce/Apama/bin:$PATH \
+    LD_LIBRARY_PATH=/opt/apamacce/Apama/lib:/opt/apamacce/Apama/../common/security/openssl/lib:$LD_LIBRARY_PATH 
+
+# Standard server port for the correlator CEP/Streaming-Analytics engine
+EXPOSE 15903
+
+# Primary binary for the CEP/Streaming-Analytics engine, but the image also 
+# contains the standard tools such as engine_inject, engine_send, etc
+CMD ["correlator"]

--- a/apamacore-ubuntu_amd64/README.md
+++ b/apamacore-ubuntu_amd64/README.md
@@ -1,0 +1,34 @@
+# (Unofficial) Apama Core Community Edition on Ubuntu Linux 
+Dockerfile for an _unofficial_ Apama Core Community Edition on a Ubuntu base image.
+
+## Images and tags
+The image can be found on DockerHub as specific tags on the `kpalf/apamacore` repo.  The images there are for a mix of architectures and Operating Systems, so please carefully choose the correct tag.
+
+Lookup the tags at: https://hub.docker.com/r/kpalf/apamacore/tags/
+
+You will also see tags for Apama Core on a Windows Server version 1709 Nano Server base image, so please be careful.
+
+For example, for the Ubuntu (amd64) base initially there will be the following tagged image that you can pull with the following command:
+```
+docker pull kpalf/apamacore:10.2.0.1_ubuntu_amd64
+```
+
+## Unofficial
+This is an unofficial, community-member contribution only.  
+Use at your own risk.
+
+At the time of writing, the only "official" distribution of Apama by Software AG as a pre-built Docker image was the one on a linux CentOS:7 (amd64) base image and distributed (free) on DockerStore: https://store.docker.com/images/apama-correlator
+
+## Apama Community
+To find out more about Apama, access full documentation, and download the distribution and samples, visit http://www.apamacommunity.com
+
+
+## Base image
+The base image is "ubuntu:18.04", which at the time of writing is Ubuntu version 18.04 ("bionic")
+
+
+## Licenses
+Please refer to the following URL for terms for the Apama Core Community Edition:
+http://www.apamacommunity.com/terms-conditions/
+And also, that link will normally be presenting the Software AG general license, and the primary difference from the commercial version is highlighted in "PART F: PRODUCT SPECIFIC TERMS for Apama Core Community Edition".
+

--- a/apamacore-ubuntu_amd64/build.sh
+++ b/apamacore-ubuntu_amd64/build.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker build -t apamacore:ubuntu_amd64 .

--- a/apamacore-ubuntu_amd64/tag.sh
+++ b/apamacore-ubuntu_amd64/tag.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+docker tag apamacore:ubuntu_amd64 kpalf/apamacore:10.2.0.1_ubuntu_amd64
+docker tag apamacore:ubuntu_amd64 kpalf/apamacore:ubuntu_amd64

--- a/apamacore-ubuntu_amd64/test-version.sh
+++ b/apamacore-ubuntu_amd64/test-version.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker run --rm kpalf/apamacore:10.2.0.1_ubuntu_amd64 correlator --version


### PR DESCRIPTION
Initial checkin of Apama Core Community Edition version 10.2.0.1 on an Ubuntu 18.04 (amd64) linux base image.  The Ubuntu 18.04 base image is smaller than the CentOS 7.4 base image, but requires a Multistage build.  Also change base install path to /opt/softwareag to be more similar to official images.