### PR TITLE
Update to new Microsoft nanoserver 1803 base image

### DIFF
--- a/apamacore-nanoserver_amd64/Dockerfile
+++ b/apamacore-nanoserver_amd64/Dockerfile
@@ -5,32 +5,53 @@
 #   http://documentation.softwareag.com/legal/general_license.txt
 #   https://hub.docker.com/r/microsoft/nanoserver/
 
-############################################################
-# This Docker file assumes that the zip file:
-#    https://downloads.apamacommunity.com/apama-core/10.2.0.1/apama_core_10.2.0.1_amd64_win.zip
-# has been downloaded and extracted to folder named "apama_core_10.2.0.1_amd64_win" 
-# alongside this Dockerfile
-############################################################
+ARG SAG_HOME=C:\\SoftwareAG
+ARG ACCE_VERSION=10.2.0.1
+ARG ACCE_LIBRARY_VERSION=10.2
 
-FROM microsoft/nanoserver:1709
+#####################################################################
+# Docker Multi-stage build
+
+#####################################################################
+# First our builder image that does the download of Apama Core
+FROM microsoft/nanoserver:1803 as acce_build
+ARG SAG_HOME
+ARG ACCE_VERSION
+
+# Get/download the compressed archive of Apama Core Community Edition, and unzip it
+RUN \
+    mkdir %SAG_HOME% && \ 
+    curl -s https://downloads.apamacommunity.com/apama-core/%ACCE_VERSION%/apama_core_%ACCE_VERSION%_amd64_win.zip \
+       | tar -xvf - -C %SAG_HOME% 
+
+
+#####################################################################
+# Now make the real image that will be pushed to the registry
+FROM microsoft/nanoserver:1803
+ARG SAG_HOME
+ARG ACCE_VERSION
+ARG ACCE_LIBRARY_VERSION
 
 LABEL \
     name="Apama Core Community Edition" \
     arch="x86-64" \
-    base="microsoft/nanoserver:1709" \
+    base="microsoft/nanoserver:1803" \
     maintainer="Kev Palfreyman (@kpalf)" \
-    build-date="20180421"
+    build-date="20180513" \
+    version=${ACCE_VERSION}
 
 # Set environment variables inside the image
 ENV \
-    APAMA_HOME=C:\\apamacce\\Apama 
+    APAMA_HOME=${SAG_HOME}\\Apama \
+    APAMA_WORK=C:\\ApamaWork \
+    APAMA_LIBRARY_VERSION=${ACCE_LIBRARY_VERSION} \
+    APAMA_PLATFORM=amd64-win
 
-# Get/download the compressed archive of Apama Core Community Edition, and unzip it
-### Can't do that yet so use local filesystem
 
-# simple local filesystem copy for now (makes use of the WORKDIR)
-WORKDIR /apamacce
-COPY ./apama_core_10.2.0.1_amd64_win ./
+# Copy the unzipped Apama Core Community Edition, from the first-stage interim builder image
+COPY --from=acce_build ${SAG_HOME} ${SAG_HOME}
+
+WORKDIR ${APAMA_WORK}
 RUN setx PATH %PATH%;%APAMA_HOME%\bin;%APAMA_HOME%\..\common\security\openssl\bin 
 
 

--- a/apamacore-nanoserver_amd64/README.md
+++ b/apamacore-nanoserver_amd64/README.md
@@ -6,11 +6,12 @@ The image can be found on DockerHub as specific tags on the `kpalf/apamacore` re
 
 Lookup the tags at: https://hub.docker.com/r/kpalf/apamacore/tags/
 
-You will also see tags for Apama Core on a CentOS base image, so please be careful.
+You will also see tags for Apama Core on other base images such as CentOS (amd64), Ubuntu (amd64), Raspbian (ARM32v7hf), so please be careful.
 
-For example, for the nanoserver base initially there will be the following tagged image that you can pull with the following command:
+The first nanoserver image for this repository was using version 1709, but as new releases become available it's moved forward, for example with version 1803.
+The nanoserver 1803 based image for Apama Core can be pulled with the following command:
 ```
-docker pull kpalf/apamacore:10.2.0.1_nanoserver_amd64_1709
+docker pull kpalf/apamacore:10.2.0.1_nanoserver_amd64_1803
 ```
 
 ## Unofficial
@@ -25,18 +26,19 @@ To find out more about Apama, access full documentation, and download the distri
 
 ## Base image
 Windows Server Nano Server has undergone significant changes since first release.  The first LTS or GA release is known as `"10.0.14393.<build-number>"` and is around 400MB.
-However, the ones we want are the smaller ones that started with the "Fall Creators Update" or "1709", with tags `"1709_KB<knowledge-base-id>"`.  These started nice and small at 93MB, but have grown with each monthly update - the Jan 2018 is 124MB.
+However, the ones we want are the smaller ones that started with the "Fall Creators Update" or "1709", with tags `"1709_KB<knowledge-base-id>"`, and later the "1803" release.  The 1709 release started nice and small at 93MB when it was first released, but have grown with each monthly update - the May 2018 is 132MB.  The first 1803 release in May 2018 is 115MB.
 
-To use the nanoserver 1709 image, and layered images such as this one, your host OS needs to be either Windows 10 (Fall Creators Update), or Windows Server version 1709.
+To use the nanoserver 1709 image, and layered images such as this one, your host OS needs to be either Windows 10 (Fall Creators Update / 1709), or Windows Server version 1709.
+To use the nanoserver 1803 image, and layered images such as this one, your host OS needs to be either Windows 10 (1803), or Windows Server version 1803.  The 1803 image might work on a 1709 host but is NOT recommended (I don't test this).
+
 For more info on Windows Container version compatibility wee the following:
 https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility
 
 
 ## Building
-The nanoserver:1709 version is nice and small due to removal of things like Windows Powershell, but that makes downloading and extracting remote archives tricky when building the image from the Dockerfile.
+The nanoserver:1709 version is nice and small due to removal of things like Windows Powershell, but that makes downloading and extracting remote archives tricky when building the image from the Dockerfile. So building the earlier 1709 versions of this image needed the Apama Core archive to be downloaded and extracted on the host filesytem alongside the Dockerfile.  To see how this was done, look in the GitHub history of this repo.
 
-This Dockerfile will be improved in future (e.g. multi-stage), but for now it assumes the Apama Core archive has been downloaded and extracted on the host filesytem alongside the Dockerfile.
-
+Since nanoserver:1803 added curl and bsdtar, that meant that the Dockerfile could be improved to automatically download and extract the Apama Core archive as part of the build.
 
 ## Licenses
 Please refer to the following URL for terms for the Microsoft nanoserver base image:

--- a/apamacore-nanoserver_amd64/build.bat
+++ b/apamacore-nanoserver_amd64/build.bat
@@ -1,1 +1,1 @@
-docker build -t apamacore:nanoserver_amd64 .
+docker build -t apamacore:nanoserver_amd64_1803 .

--- a/apamacore-nanoserver_amd64/tag.bat
+++ b/apamacore-nanoserver_amd64/tag.bat
@@ -1,1 +1,1 @@
-docker tag apamacore:nanoserver_amd64 kpalf/apamacore:10.2.0.1_nanoserver_amd64_1709
+docker tag apamacore:nanoserver_amd64_1803 kpalf/apamacore:10.2.0.1_nanoserver_amd64_1803

--- a/apamacore-nanoserver_amd64/test-version.bat
+++ b/apamacore-nanoserver_amd64/test-version.bat
@@ -1,2 +1,2 @@
-docker run --rm apamacore:nanoserver_amd64 correlator --version
-docker run --rm kpalf/apamacore:10.2.0.1_nanoserver_amd64_1709 correlator --version
+docker run --rm apamacore:nanoserver_amd64_1803 correlator --version
+docker run --rm kpalf/apamacore:10.2.0.1_nanoserver_amd64_1803 correlator --version


### PR DESCRIPTION
Update to new Microsoft nanoserver 1803 base image, use curl and tar to download and extract, and make environment variables and folders more similar to official images or installations