### PR TITLE
Acce 10.3.0.1 ldlibpath

### DIFF
--- a/apamacore-centos_amd64/Dockerfile
+++ b/apamacore-centos_amd64/Dockerfile
@@ -32,7 +32,7 @@ LABEL \
     arch="x86-64" \
     base="centos:7" \
     maintainer="Kev Palfreyman (@kpalf)" \
-    build-date="20181014" \
+    build-date="20181022" \
     version=${ACCE_VERSION}
 
 # Set the shell and create user identical to the official SAG images
@@ -50,7 +50,7 @@ ENV \
     APAMA_LIBRARY_VERSION=${ACCE_LIBRARY_VERSION} \
     APAMA_PLATFORM=amd64_linux \
     PATH=${APAMA_HOME}/bin:$PATH \
-    LD_LIBRARY_PATH=${APAMA_HOME}/lib:${APAMA_WORK}/lib:${APAMA_HOME}/../common/security/openssl/lib:$LD_LIBRARY_PATH \
+    LD_LIBRARY_PATH=${APAMA_HOME}/lib:${APAMA_WORK}/lib:$LD_LIBRARY_PATH \
     PYTHONPATH=${APAMA_HOME}/third_party/python/lib/python3.6/site-packages
 
 RUN ldconfig

--- a/apamacore-centos_amd64/tag.sh
+++ b/apamacore-centos_amd64/tag.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 docker tag apamacore:centos_amd64 kpalf/apamacore:10.3.0.1_centos_amd64
-docker tag apamacore:centos_amd64 kpalf/apamacore:10.3.0.1
+# docker tag apamacore:centos_amd64 kpalf/apamacore:10.3.0.1
 docker tag apamacore:centos_amd64 kpalf/apamacore:centos_amd64
-docker tag apamacore:centos_amd64 kpalf/apamacore:latest
+# docker tag apamacore:centos_amd64 kpalf/apamacore:latest

--- a/apamacore-raspbian_armv7hf/Dockerfile
+++ b/apamacore-raspbian_armv7hf/Dockerfile
@@ -37,7 +37,7 @@ LABEL \
     arch="armv7hf" \
     base="resin/rpi-raspbian:jessie" \
     maintainer="Kev Palfreyman (@kpalf)" \
-    build-date="20181015" \
+    build-date="20181022" \
     version=${ACCE_VERSION}
 
 # Set the shell and create user identical to the official SAG images
@@ -55,7 +55,7 @@ ENV \
     APAMA_LIBRARY_VERSION=${ACCE_LIBRARY_VERSION} \
     APAMA_PLATFORM=armv7_linux \
     PATH=${APAMA_HOME}/bin:$PATH \
-    LD_LIBRARY_PATH=${APAMA_HOME}/lib:${APAMA_WORK}/lib:${APAMA_HOME}/../common/security/openssl/lib:$LD_LIBRARY_PATH \
+    LD_LIBRARY_PATH=${APAMA_HOME}/lib:${APAMA_WORK}/lib:$LD_LIBRARY_PATH \
     PYTHONPATH=${APAMA_HOME}/third_party/python/lib/python3.6/site-packages
 
 RUN ldconfig

--- a/apamacore-ubuntu_amd64/Dockerfile
+++ b/apamacore-ubuntu_amd64/Dockerfile
@@ -36,7 +36,7 @@ LABEL \
     arch="x86-64" \
     base="ubuntu:18.10" \
     maintainer="Kev Palfreyman (@kpalf)" \
-    build-date="20181014" \
+    build-date="20181022" \
     version=${ACCE_VERSION}
 
 # Set the shell and create user identical to the official SAG images
@@ -54,7 +54,7 @@ ENV \
     APAMA_LIBRARY_VERSION=${ACCE_LIBRARY_VERSION} \
     APAMA_PLATFORM=amd64_linux \
     PATH=${APAMA_HOME}/bin:$PATH \
-    LD_LIBRARY_PATH=${APAMA_HOME}/lib:${APAMA_WORK}/lib:${APAMA_HOME}/../common/security/openssl/lib:$LD_LIBRARY_PATH \
+    LD_LIBRARY_PATH=${APAMA_HOME}/lib:${APAMA_WORK}/lib:$LD_LIBRARY_PATH \
     PYTHONPATH=${APAMA_HOME}/third_party/python/lib/python3.6/site-packages
 
 RUN ldconfig


### PR DESCRIPTION
Fix issue 14 where local openssl was on LD_LIBRARY_PATH.
Stop using latest tag, and bare version tags.